### PR TITLE
Adds "List with featured podcast" layout

### DIFF
--- a/shoutem.podcast/.expo/README.md
+++ b/shoutem.podcast/.expo/README.md
@@ -1,0 +1,17 @@
+> Why do I have a folder named ".expo" in my project?
+
+The ".expo" folder is created when an Expo project is started using "expo start" command.
+
+> What does the "packager-info.json" file contain?
+
+The "packager-info.json" file contains port numbers and process PIDs that are used to serve the application to the mobile device/simulator.
+
+> What does the "settings.json" file contain?
+
+The "settings.json" file contains the server configuration that is used to serve the application manifest.
+
+> Should I commit the ".expo" folder?
+
+No, you should not share the ".expo" folder. It does not contain any information that is relevant for other developers working on the project, it is specific to your machine.
+
+Upon project creation, the ".expo" folder is already added to your ".gitignore" file.

--- a/shoutem.podcast/.expo/settings.json
+++ b/shoutem.podcast/.expo/settings.json
@@ -1,0 +1,9 @@
+{
+  "hostType": "lan",
+  "lanType": "ip",
+  "dev": true,
+  "minify": false,
+  "urlRandomness": null,
+  "https": false,
+  "scheme": null
+}

--- a/shoutem.podcast/app/extension.js
+++ b/shoutem.podcast/app/extension.js
@@ -1,0 +1,20 @@
+// This file is managed by Shoutem CLI
+// It exports screens and themes from extension.json
+// You should not change it manually
+
+// screens imports
+import EpisodesListScreen from './screens/EpisodesListScreen';
+import EpisodesFeaturedListScreen from './screens/EpisodesFeaturedListScreen';
+import EpisodesGridScreen from './screens/EpisodesGridScreen';
+import EpisodesFeaturedGridScreen from './screens/EpisodesFeaturedGridScreen';
+import EpisodeDetailsScreen from './screens/EpisodeDetailsScreen';
+import FeaturedPodcastView from './screens/FeaturedPodcastView';
+
+export const screens = {
+  EpisodesListScreen,
+  EpisodesFeaturedListScreen,
+  EpisodesGridScreen,
+  EpisodesFeaturedGridScreen,
+  EpisodeDetailsScreen,
+  FeaturedPodcastView
+};

--- a/shoutem.podcast/app/screens/FeaturedPodcastView.js
+++ b/shoutem.podcast/app/screens/FeaturedPodcastView.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import moment from 'moment';
+
+import {
+  TouchableOpacity,
+  Title,
+  Caption,
+  View,
+  Tile,
+  ImageBackground,
+  Divider,
+} from '@shoutem/ui';
+
+import {
+  EpisodeView,
+} from '../components/EpisodeView';
+
+/**
+ * A component used to render featured podcast 
+ */
+export class FeaturedPodcastView extends EpisodeView {
+  render() {
+    const { podcastTitle, imageUrl, date, author } = this.props;
+// Tried to pull in podcastTitle from EpisodeView
+
+    const momentDate = moment(date);
+    const dateInfo = momentDate.isAfter(0) ? (
+      <Caption styleName="md-gutter-left">
+        {momentDate.fromNow()}
+      </Caption>
+    ) : null;
+
+    return (
+      <TouchableOpacity onPress={this.onPress}>
+        <View styleName="sm-gutter featured">
+          <ImageBackground
+            source={{ uri: imageUrl }}
+            styleName="featured placeholder"
+          >
+            <Tile>
+              {/* This is where the title of the podcast would go */}
+              <Title>{(podcastTitle || '').toUpperCase()}</Title>
+              <View styleName="horizontal md-gutter-top" virtual>
+                <Caption numberOfLines={1} styleName="collapsible">
+                  {author}
+                </Caption>
+              </View>
+            </Tile>
+          </ImageBackground>
+        </View>
+        <Divider styleName="line" />
+      </TouchableOpacity>
+    );
+  }
+}

--- a/shoutem.podcast/extension.json
+++ b/shoutem.podcast/extension.json
@@ -5,19 +5,26 @@
   "title": "Podcast RSS",
   "description": "Show podcast episodes from an RSS feed",
   "icon": "server/assets/extension-icon.png",
-  "categories": ["media"],
+  "categories": [
+    "media"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/shoutem/extensions"
   },
-  "dependencies": ["shoutem.layouts", "shoutem.rss"],
+  "dependencies": [
+    "shoutem.layouts",
+    "shoutem.rss"
+  ],
   "shortcuts": [
     {
       "name": "podcast-shortcut",
       "title": "Podcast RSS",
       "icon": "theme://podcasts.png",
       "screen": "@.EpisodesListScreen",
-      "capabilities": ["shoutem.rss.feed"],
+      "capabilities": [
+        "shoutem.rss.feed"
+      ],
       "adminPages": [
         {
           "page": "shoutem.rss.RssPage",
@@ -43,7 +50,9 @@
       "name": "EpisodesListScreen",
       "title": "List",
       "image": "./server/assets/screens/list.png",
-      "navigatesTo": ["@.EpisodeDetailsScreen"],
+      "navigatesTo": [
+        "@.EpisodeDetailsScreen"
+      ],
       "settings": {
         "listType": "list",
         "hasFeaturedItem": false
@@ -83,6 +92,12 @@
       "name": "EpisodeDetailsScreen",
       "title": "Episode details",
       "image": "./server/assets/screens/large-details.png"
+    },
+    {
+      "name": "FeaturedPodcastView",
+      "title": "List with a featured podcast",
+      "image": "./server/assets/screens/featuredlist.png",
+      "extends": "@.EpisodesListScreen"
     }
   ]
 }

--- a/shoutem.podcast/server/src/extension.js
+++ b/shoutem.podcast/server/src/extension.js
@@ -1,0 +1,3 @@
+// This file is managed by Shoutem CLI
+// It exports pages from extension.json
+// You should not change it manually


### PR DESCRIPTION
This adds a new layout option for Podcast RSS feeds. This new layout features podcast instead of an episode. While unable to access the podcast information, this should show a list identical to that of "list with featured episode" except with the podcast title.